### PR TITLE
Fixing MacOS build and Spin Test

### DIFF
--- a/CorrelationVector/include/correlation_vector/spin_parameters.h
+++ b/CorrelationVector/include/correlation_vector/spin_parameters.h
@@ -12,14 +12,14 @@ enum class spin_counter_interval
     /**
         The coarse interval drops the 24 least significant bits in
        time_since_epoch resulting in a counter that increments every 1.67
-       seconds.
+       seconds (on system with 10 million ticks = 1 second).
     */
     coarse = 24,
 
     /**
         The fine interval drops the 16 least significant bits in
        time_since_epoch resulting in a counter that increments every 6.5
-       milliseconds.
+       milliseconds (on system with 10 million ticks = 1 second).
     */
     fine = 16
 };

--- a/CorrelationVector/src/guid.cpp
+++ b/CorrelationVector/src/guid.cpp
@@ -38,13 +38,13 @@ constexpr std::array<unsigned char, 16> convert_to_array(const unsigned char* g)
 }
 
 #ifdef GUID_WINDOWS
-constexpr std::array<unsigned char, 16> convert_to_array(const GUID& g)
+std::array<unsigned char, 16> convert_to_array(const GUID& g)
 {
     return impl::convert_to_array(reinterpret_cast<const unsigned char*>(&g));
 }
 #endif
 #ifdef GUID_LIBUUID
-constexpr std::array<unsigned char, 16> convert_to_array(const uuid_t& g)
+std::array<unsigned char, 16> convert_to_array(const uuid_t& g)
 {
     return impl::convert_to_array(reinterpret_cast<const unsigned char*>(g));
 }

--- a/CorrelationVector/tests/CorrelationVectorTests.cpp
+++ b/CorrelationVector/tests/CorrelationVectorTests.cpp
@@ -294,8 +294,17 @@ TEST_CASE("Spin_SortValidation")
 
         lastSpinValue = spinValue;
 
+        // MacOS SYSTEM_CLOCK and std::chrono::system_clock have microsecond precision.
+        // Both Windows and Linux have sub-microsecond precision.
+        // This means we need to wait a bit longer (over 65 milliseconds) on MacOS
+        // for the spin operator to to change the value of the cv.
+#ifdef __APPLE__
+        // Wait for 70ms
+        std::this_thread::sleep_for(std::chrono::milliseconds(70));
+#else
         // Wait for 10ms.
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
+#endif
     }
 
     // The counter should wrap at most 1 time.

--- a/CorrelationVector/tests/CorrelationVectorTests.cpp
+++ b/CorrelationVector/tests/CorrelationVectorTests.cpp
@@ -297,7 +297,7 @@ TEST_CASE("Spin_SortValidation")
         // MacOS SYSTEM_CLOCK and std::chrono::system_clock have microsecond precision.
         // Both Windows and Linux have sub-microsecond precision.
         // This means we need to wait a bit longer (over 65 milliseconds) on MacOS
-        // for the spin operator to to change the value of the cv.
+        // for the spin operator to change the value of the cV.
 #ifdef __APPLE__
         // Wait for 70ms
         std::this_thread::sleep_for(std::chrono::milliseconds(70));


### PR DESCRIPTION
MacOS build was failing when not using BOOST_UUID due to `constexpr` functions with `reinterpret_cast` in the body in guid.cpp.

Spin_SortValidation was failing because the SYSTEM_CLOCK and (std::chrono::system_clock) on MacOS only has microsecond precision which is coarser than Windows or Linux. This means we need to wait > 65 milliseconds for the spin operator to change the value of the correlation vector.